### PR TITLE
设置缺失时避免脚本闪退，在本地保存下载的图片和上次的便笺数据

### DIFF
--- a/genshinwidget_elite.js
+++ b/genshinwidget_elite.js
@@ -23,6 +23,20 @@
  * @property {number} current_expedition_num - 当前探索派遣人数
  * @property {Array<{ status: string, avatar_side_icon: string, remained_time: string }>} expeditions - 派遣人员详情 
  */
+
+// 如果上方的配置缺失，将会显示一个简单的提示语句，而非直接闪退
+if (!config[0] || !config[1] || !config[2]) {
+    const widget = new ListWidget()
+    widget.addText('配置缺失，\n请打开脚本，\n添加配置。')
+    if (config.runsInWidget) {
+        Script.setWidget(widget)
+    } else {
+        widget.presentMedium()
+    }
+    Script.complete()
+    return  // 确保在Scriptable软件内的时候会停止运行余下脚本
+}
+
 let resin = {}
 try {
     if (config[1].startsWith("os")) {

--- a/genshinwidget_elite.js
+++ b/genshinwidget_elite.js
@@ -39,12 +39,12 @@ if (!config[0] || !config[1] || !config[2]) {
 }
 
 const file = FileManager.local()
-const saveDirectory = `${file.documentsDirectory()}/genshin-widget`
+const saveDirectory = file.joinPath(file.documentsDirectory(), 'genshin-widget')
 if (!file.isDirectory(saveDirectory)) {
     file.createDirectory(saveDirectory)
 }
 
-const responseSavePath = `${saveDirectory}/last-response.json`
+const responseSavePath = file.joinPath(saveDirectory, 'last-response.json')
 let resin
 try {
     if (config[1].startsWith("os")) {
@@ -999,7 +999,7 @@ async function renderMedium(widget) {
     expeditionsTitleElement.font = Font.mediumSystemFont(ThemeConfig.textSize)
     let expeditionsStack = RightRow2.addStack()
     expeditionsStack.addSpacer()
-    const iconSaveDirectory = `${saveDirectory}/avatar-icons`
+    const iconSaveDirectory = file.joinPath(saveDirectory, 'avatar-icons')
     if (!file.isDirectory(iconSaveDirectory)) {
         file.createDirectory(iconSaveDirectory)
     }
@@ -1007,7 +1007,7 @@ async function renderMedium(widget) {
     await Promise.all(expeditions.map(async (expedition) => {
         // 网址示例 https://.../game_record/genshin/character_side_icon/UI_AvatarIcon_Side_Yelan.png
         const iconUrl = expedition.avatar_side_icon
-        const iconPath = `${iconSaveDirectory}/${iconUrl.substring(iconUrl.lastIndexOf('/') + 1)}`
+        const iconPath = file.joinPath(iconSaveDirectory, iconUrl.substring(iconUrl.lastIndexOf('/') + 1))
         const icon = Image.fromFile(iconPath)
         if (icon) {
             expedition.icon = icon

--- a/genshinwidget_elite.js
+++ b/genshinwidget_elite.js
@@ -22,6 +22,7 @@
  * @property {number} max_expedition_num - 探索派遣限制
  * @property {number} current_expedition_num - 当前探索派遣人数
  * @property {Array<{ status: string, avatar_side_icon: string, remained_time: string }>} expeditions - 派遣人员详情 
+ * @property {string} _time_string - 便笺数据获取时间 - 额外添加的时间戳属性
  */
 
 // 如果上方的配置缺失，将会显示一个简单的提示语句，而非直接闪退
@@ -43,16 +44,25 @@ if (!file.isDirectory(saveDirectory)) {
     file.createDirectory(saveDirectory)
 }
 
-let resin = {}
+const responseSavePath = `${saveDirectory}/last-response.json`
+let resin
 try {
     if (config[1].startsWith("os")) {
         resin = await getDataOs()
     } else {
         resin = await getData()
     }
-    resin = resin || {}
+    if (resin) {
+        var myDate = new Date()
+        resin._time_string = `${myDate.getHours().toString().padStart(2, '0')}:${myDate.getMinutes().toString().padStart(2, '0')}`
+        file.writeString(responseSavePath, JSON.stringify(resin))
+    }
 } catch (error) {
     console.error(error)
+}
+
+if (!resin) {
+    resin = JSON.parse(file.readString(responseSavePath))
 }
 
 // 背景图片定义
@@ -210,8 +220,7 @@ async function renderSmall(widget) {
     textItem.font = Font.boldRoundedSystemFont(ThemeConfig.titleSize)
     textItem.textColor = ThemeColor.infoColor
     // 添加更新时间
-    var myDate = new Date()
-    var textItem = stacktime.addText(`${myDate.getHours().toString().padStart(2, '0')}:${myDate.getMinutes().toString().padStart(2, '0')}更新`)
+    var textItem = stacktime.addText(`${resin._time_string}更新`)
     textItem.font = Font.boldRoundedSystemFont(ThemeConfig.titleSize)
     textItem.textColor = ThemeColor.infoColor
 
@@ -556,8 +565,7 @@ async function renderMedium(widget) {
     server.textColor = ThemeColor.infoColor
     server.font = Font.boldSystemFont(ThemeConfig.titleSize)
     // 添加更新时间
-    var myDate = new Date()
-    var textItem = stacktime.addText(`最近${myDate.getHours().toString().padStart(2, '0')}:${myDate.getMinutes().toString().padStart(2, '0')}更新`)
+    var textItem = stacktime.addText(`最近${resin._time_string}更新`)
     textItem.font = Font.boldRoundedSystemFont(ThemeConfig.titleSize)
     textItem.textColor = ThemeColor.infoColor
 
@@ -1151,7 +1159,7 @@ async function getDataOs() {
 
     let resp = await req.loadJSON()
     let data = resp.data
-
+    
     return data
 }
 


### PR DESCRIPTION
1. 添加配置缺失的提示文本，并且避免脚本在Scriptable内执行时由于缺失设置而闪退
2. 将下载的角色头像图片保存在本地，极大地减少了下载头像图片的次数，节省流量
3. 将下载的便笺数据保存在本地，在断网时显示上次数据，并避免显示网络断开的报错画面

![8d895ff15110d7e41af0dee0f67af35](https://user-images.githubusercontent.com/3869257/182985831-112a67e1-e615-4e7c-ae52-6e57fab2a3bc.jpg)
