### PR TITLE
重新命名 last-response.json

### DIFF
--- a/genshinwidget_elite.js
+++ b/genshinwidget_elite.js
@@ -44,7 +44,8 @@ if (!file.isDirectory(saveDirectory)) {
     file.createDirectory(saveDirectory)
 }
 
-const responseSavePath = file.joinPath(saveDirectory, 'last-response.json')
+const saveFileName = `last-response-${config[0]}-.json`
+const responseSavePath = file.joinPath(saveDirectory, saveFileName)
 let resin
 try {
     if (config[1].startsWith("os")) {


### PR DESCRIPTION
有多个帐号的时候会只会显示其中一个号。把存放最后请求的JSON档案(`last-response.json`)名字加入帐号UID将不同帐号区分开就可以正常显示全部帐号。

另外Scriptable可以import其他脚本，想问能否为现在的脚本加入module.exports，方便在其他脚本以参数方式把不同cookie传进去来达到支援多帐号。目前的话每个帐号都要複製一次整个脚本，未来要更新也不方便。